### PR TITLE
Define Natvis for core regex types and enable the #[debugger_visualizer] attribute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         - nightly
         - macos
         - win-msvc
+        - win-msvc (nightly)
         - win-gnu
         include:
         - build: pinned
@@ -55,6 +56,9 @@ jobs:
         - build: win-msvc
           os: windows-latest
           rust: stable
+        - build: win-msvc (nightly)
+          os: windows-latest
+          rust: nightly
         - build: win-gnu
           os: windows-latest
           rust: stable-x86_64-gnu
@@ -153,6 +157,13 @@ jobs:
       name: Run tests with pattern feature
       run: |
         cargo test --test default --no-default-features --features 'std pattern unicode-perl'
+
+    # The #[debugger_visualizer] attribute is currently gated behind an unstable feature flag.
+    # In order to test the visualizers for the regex crate, they have to be tested on a nightly build.
+    - if: matrix.build == 'win-msvc (nightly)'
+      name: Run tests with debugger_visualizer feature
+      run: |
+        cargo test --test visualizers --features 'debugger_visualizer' -- --test-threads=1
 
   rustfmt:
     name: rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,9 @@ unstable = ["pattern"]
 # by default if the unstable feature is enabled.
 pattern = []
 
+# Enable to use the #[debugger_visualizer] attribute.
+debugger_visualizer = []
+
 # For very fast prefix literal matching.
 [dependencies.aho-corasick]
 version = "0.7.18"
@@ -132,6 +135,9 @@ rand = { version = "0.8.3", default-features = false, features = ["getrandom", "
 # See: https://github.com/rust-lang/regex/issues/684
 # See: https://github.com/rust-lang/regex/issues/685
 # doc-comment = "0.3"
+# To test debugger visualizers defined for the regex crate such as regex.natvis
+debugger_test = "0.1.0"
+debugger_test_parser = "0.1.0"
 
 # Run the test suite on the default behavior of Regex::new.
 # This includes a mish mash of NFAs and DFAs, which are chosen automatically
@@ -183,6 +189,10 @@ name = "backtrack-bytes"
 [[test]]
 path = "tests/test_crates_regex.rs"
 name = "crates-regex"
+
+[[test]]
+path = "tests/test_visualizers.rs"
+name = "visualizers"
 
 [profile.release]
 debug = true

--- a/regex.natvis
+++ b/regex.natvis
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="regex::re_builder::unicode::RegexBuilder">
+    <DisplayString>{{ text={__0.pats[0]} }}</DisplayString>
+    <Expand>
+      <ExpandedItem>__0</ExpandedItem>
+    </Expand>
+  </Type>
+
+  <Type Name="regex::re_bytes::Captures">
+    <Intrinsic Name="discriminant" Expression="locs.__0.buf.ptr.pointer.pointer[i].discriminant">
+      <Parameter Name="i" Type="int" />
+    </Intrinsic>
+    <Intrinsic Name="location" Expression="locs.__0.buf.ptr.pointer.pointer[i].variant1.__0">
+      <Parameter Name="i" Type="int" />
+    </Intrinsic>
+    <Intrinsic Name="match_length" Expression="location(end)-location(start)">
+      <Parameter Name="start" Type="int" />
+      <Parameter Name="end" Type="int" />
+    </Intrinsic>
+    <DisplayString>{{ named_groups={named_groups.ptr.pointer->data.base.table.table.items} }}</DisplayString>
+    <Expand>
+      <Item Name="[text]">text</Item>
+      <Item Name="[named_groups]">named_groups</Item>
+      <CustomListItems>
+        <Variable Name="i" InitialValue="0" />
+        <Variable Name="index" InitialValue="0" />
+        <Variable Name="len" InitialValue="locs.__0.len" />
+        <Loop>
+          <Break Condition="i &gt;= len || discriminant(i) == 0" />
+          <Item Name="{index}">(char*)text.data_ptr+location(i),[location(i+1)-location(i)]s8</Item>
+          <Exec>i+=2</Exec>
+          <Exec>index++</Exec>
+        </Loop>
+      </CustomListItems>
+    </Expand>
+  </Type>
+
+  <Type Name="regex::re_bytes::Match">
+    <DisplayString>{text.data_ptr+start,[end-start]s8}</DisplayString>
+    <Expand>
+      <Item Name="[text]">text</Item>
+      <Synthetic Name="[match_text]">
+        <DisplayString>{(char*)text.data_ptr+start,[end-start]s8}</DisplayString>
+      </Synthetic>
+      <Item Name="[start]">start,d</Item>
+      <Item Name="[end]">end,d</Item>
+    </Expand>
+  </Type>
+
+  <Type Name="regex::re_bytes::Regex">
+    <DisplayString>{{ text={__0.ro.ptr.pointer->data.res[0]} }}</DisplayString>
+    <Expand>
+      <ExpandedItem>__0.ro</ExpandedItem>
+    </Expand>
+  </Type>
+
+  <Type Name="regex::re_unicode::Captures">
+    <Intrinsic Name="discriminant" Expression="locs.__0.buf.ptr.pointer.pointer[i].discriminant">
+      <Parameter Name="i" Type="int" />
+    </Intrinsic>
+    <Intrinsic Name="location" Expression="locs.__0.buf.ptr.pointer.pointer[i].variant1.__0">
+      <Parameter Name="i" Type="int" />
+    </Intrinsic>
+    <Intrinsic Name="match_length" Expression="location(end)-location(start)">
+      <Parameter Name="start" Type="int" />
+      <Parameter Name="end" Type="int" />
+    </Intrinsic>
+    <DisplayString>{{ named_groups={named_groups.ptr.pointer->data.base.table.table.items} }}</DisplayString>
+    <Expand>
+      <Item Name="[text]">text</Item>
+      <Item Name="[named_groups]">named_groups</Item>
+      <CustomListItems>
+        <Variable Name="i" InitialValue="0" />
+        <Variable Name="index" InitialValue="0" />
+        <Variable Name="len" InitialValue="locs.__0.len" />
+        <Loop>
+          <Break Condition="i &gt;= len || discriminant(i) == 0" />
+          <Item Name="{index}">(char*)text.data_ptr+location(i),[location(i+1)-location(i)]s8</Item>
+          <Exec>i+=2</Exec>
+          <Exec>index++</Exec>
+        </Loop>
+      </CustomListItems>
+    </Expand>
+  </Type>
+
+  <Type Name="regex::re_unicode::Match">
+    <DisplayString>{text.data_ptr+start,[end-start]s8}</DisplayString>
+    <Expand>
+      <Item Name="[text]">text</Item>
+      <Synthetic Name="[match_text]">
+        <DisplayString>{(char*)text.data_ptr+start,[end-start]s8}</DisplayString>
+      </Synthetic>
+      <Item Name="[start]">start,d</Item>
+      <Item Name="[end]">end,d</Item>
+    </Expand>
+  </Type>
+
+  <Type Name="regex::re_unicode::Regex">
+    <DisplayString>{{ text={__0.ro.ptr.pointer->data.res[0]} }}</DisplayString>
+    <Expand>
+      <ExpandedItem>__0.ro</ExpandedItem>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,6 +607,11 @@ another matching engine with fixed memory requirements.
 
 #![deny(missing_docs)]
 #![cfg_attr(feature = "pattern", feature(pattern))]
+#![cfg_attr(feature = "debugger_visualizer", feature(debugger_visualizer))]
+#![cfg_attr(
+    feature = "debugger_visualizer",
+    debugger_visualizer(natvis_file = "../regex.natvis")
+)]
 #![warn(missing_debug_implementations)]
 
 #[cfg(not(feature = "std"))]

--- a/tests/debugger_visualizer.rs
+++ b/tests/debugger_visualizer.rs
@@ -1,0 +1,191 @@
+use debugger_test::debugger_test;
+
+#[inline(never)]
+fn __break() {}
+
+#[debugger_test(
+    debugger = "cdb",
+    commands = r#"
+.nvlist
+dv
+dx re
+dx captures
+g
+dx m1
+dx m2
+dx m3
+dx m4
+"#,
+    expected_statements = r#"
+re               : { text="^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})$" } [Type: regex::re_unicode::Regex]
+[<Raw View>]     [Type: regex::re_unicode::Regex]
+[Reference count] : 0x2 [Type: core::sync::atomic::AtomicUsize]
+[Weak reference count] : 0x1 [Type: core::sync::atomic::AtomicUsize]
+[+0xc00] res              : { len=0x1 } [Type: alloc::vec::Vec<alloc::string::String,alloc::alloc::Global>]
+[+0x000] nfa              [Type: regex::prog::Program]
+[+0x320] dfa              [Type: regex::prog::Program]
+[+0x640] dfa_reverse      [Type: regex::prog::Program]
+[+0x960] suffixes         [Type: regex::literal::imp::LiteralSearcher]
+[+0xc18] ac               : None [Type: enum$<core::option::Option<aho_corasick::ahocorasick::AhoCorasick<u32> >, 0, 1, Some>]
+[+0xda0] match_type       : Dfa [Type: enum$<regex::exec::MatchType>]
+
+captures         : { named_groups=0x3 } [Type: regex::re_unicode::Captures]
+[<Raw View>]     [Type: regex::re_unicode::Captures]
+[text]           : "2020-10-15" [Type: str]
+pattern:\[named_groups\]   : \{ len=0x3 \} \[Type: .*\]
+pattern:\[0\]              : .* : "2020-10-15" \[Type: char \*\]
+pattern:\[1\]              : .* : "2020" \[Type: char \*\]
+pattern:\[2\]              : .* : "10" \[Type: char \*\]
+pattern:\[3\]              : .* : "15" \[Type: char \*\]
+
+m1               : "2020-10-15" [Type: regex::re_unicode::Match]
+[<Raw View>]     [Type: regex::re_unicode::Match]
+[text]           : "2020-10-15" [Type: str]
+[match_text]     : "2020-10-15"
+[start]          : 0 [Type: unsigned __int64]
+[end]            : 10 [Type: unsigned __int64]
+
+m2               : "2020" [Type: regex::re_unicode::Match]
+[<Raw View>]     [Type: regex::re_unicode::Match]
+[text]           : "2020-10-15" [Type: str]
+[match_text]     : "2020"
+[start]          : 0 [Type: unsigned __int64]
+[end]            : 4 [Type: unsigned __int64]
+
+m3               : "10" [Type: regex::re_unicode::Match]
+[<Raw View>]     [Type: regex::re_unicode::Match]
+[text]           : "2020-10-15" [Type: str]
+[match_text]     : "10"
+[start]          : 5 [Type: unsigned __int64]
+[end]            : 7 [Type: unsigned __int64]
+
+m4               : "15" [Type: regex::re_unicode::Match]
+[<Raw View>]     [Type: regex::re_unicode::Match]
+[text]           : "2020-10-15" [Type: str]
+[match_text]     : "15"
+[start]          : 8 [Type: unsigned __int64]
+[end]            : 10 [Type: unsigned __int64]
+"#
+)]
+fn test_debugger_visualizer() {
+    let re = regex::Regex::new(
+        r"^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})$",
+    )
+    .unwrap();
+    let text = "2020-10-15";
+
+    let captures = re.captures(text).unwrap();
+    let matches = captures
+        .iter()
+        .filter_map(|capture| capture)
+        .collect::<Vec<regex::Match>>();
+    assert_eq!(4, matches.len());
+    __break(); // #break
+
+    let m1 = matches[0];
+    assert_eq!("2020-10-15", m1.as_str());
+
+    let m2 = matches[1];
+    assert_eq!("2020", m2.as_str());
+
+    let m3 = matches[2];
+    assert_eq!("10", m3.as_str());
+
+    let m4 = matches[3];
+    assert_eq!("15", m4.as_str());
+    __break(); // #break
+}
+
+#[debugger_test(
+    debugger = "cdb",
+    commands = r#"
+.nvlist
+dv
+dx re
+dx captures
+g
+dx m1
+dx m2
+dx m3
+dx m4
+"#,
+    expected_statements = r#"
+re               : { text="^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})$" } [Type: regex::re_bytes::Regex]
+[<Raw View>]     [Type: regex::re_bytes::Regex]
+[Reference count] : 0x2 [Type: core::sync::atomic::AtomicUsize]
+[Weak reference count] : 0x1 [Type: core::sync::atomic::AtomicUsize]
+[+0xc00] res              : { len=0x1 } [Type: alloc::vec::Vec<alloc::string::String,alloc::alloc::Global>]
+[+0x000] nfa              [Type: regex::prog::Program]
+[+0x320] dfa              [Type: regex::prog::Program]
+[+0x640] dfa_reverse      [Type: regex::prog::Program]
+[+0x960] suffixes         [Type: regex::literal::imp::LiteralSearcher]
+[+0xc18] ac               : None [Type: enum$<core::option::Option<aho_corasick::ahocorasick::AhoCorasick<u32> >, 0, 1, Some>]
+[+0xda0] match_type       : Dfa [Type: enum$<regex::exec::MatchType>]
+
+captures         : { named_groups=0x3 } [Type: regex::re_bytes::Captures]
+[<Raw View>]     [Type: regex::re_bytes::Captures]
+[text]           : { len=0xa } [Type: slice$<u8>]
+pattern:\[named_groups\]   : \{ len=0x3 \} \[Type: .*\]
+pattern:\[0\]              : .* : "2020-10-15" \[Type: char \*\]
+pattern:\[1\]              : .* : "2020" \[Type: char \*\]
+pattern:\[2\]              : .* : "10" \[Type: char \*\]
+pattern:\[3\]              : .* : "15" \[Type: char \*\]
+
+m1               : "2020-10-15" [Type: regex::re_bytes::Match]
+[<Raw View>]     [Type: regex::re_bytes::Match]
+[text]           : { len=0xa } [Type: slice$<u8>]
+[match_text]     : "2020-10-15"
+[start]          : 0 [Type: unsigned __int64]
+[end]            : 10 [Type: unsigned __int64]
+
+m2               : "2020" [Type: regex::re_bytes::Match]
+[<Raw View>]     [Type: regex::re_bytes::Match]
+[text]           : { len=0xa } [Type: slice$<u8>]
+[match_text]     : "2020"
+[start]          : 0 [Type: unsigned __int64]
+[end]            : 4 [Type: unsigned __int64]
+
+m3               : "10" [Type: regex::re_bytes::Match]
+[<Raw View>]     [Type: regex::re_bytes::Match]
+[text]           : { len=0xa } [Type: slice$<u8>]
+[match_text]     : "10"
+[start]          : 5 [Type: unsigned __int64]
+[end]            : 7 [Type: unsigned __int64]
+
+m4               : "15" [Type: regex::re_bytes::Match]
+[<Raw View>]     [Type: regex::re_bytes::Match]
+[text]           : { len=0xa } [Type: slice$<u8>]
+[match_text]     : "15"
+[start]          : 8 [Type: unsigned __int64]
+[end]            : 10 [Type: unsigned __int64]
+"#
+)]
+fn test_bytes_debugger_visualizer() {
+    let re = regex::bytes::Regex::new(
+        r"^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})$",
+    )
+    .unwrap();
+    let text = b"2020-10-15";
+
+    let captures = re.captures(text).unwrap();
+    let matches = captures
+        .iter()
+        .filter_map(|capture| capture)
+        .collect::<Vec<regex::bytes::Match>>();
+    assert_eq!(4, matches.len());
+    __break(); // #break
+
+    let m1 = matches[0];
+    assert_eq!(b"2020-10-15", m1.as_bytes());
+
+    let m2 = matches[1];
+    assert_eq!(b"2020", m2.as_bytes());
+
+    let m3 = matches[2];
+    assert_eq!(b"10", m3.as_bytes());
+
+    let m4 = matches[3];
+    assert_eq!(b"15", m4.as_bytes());
+
+    __break(); // #break
+}

--- a/tests/test_visualizers.rs
+++ b/tests/test_visualizers.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "debugger_visualizer")]
+mod debugger_visualizer;


### PR DESCRIPTION
Define Natvis for core regex types and add a framework for testing the visualizations to ensure they do not become stale.